### PR TITLE
Principal support for colored prompts.

### DIFF
--- a/shell/prompt-types-grovel.lisp
+++ b/shell/prompt-types-grovel.lisp
@@ -28,6 +28,7 @@
          (lastchar "lastchar" :type (:pointer :char)))
 
 (constant (+el-prompt+ "EL_PROMPT"))
+(constant (+el-prompt-esc+ "EL_PROMPT_ESC"))
 (constant (+el-rprompt+ "EL_RPROMPT"))
 (constant (+el-editor+ "EL_EDITOR"))
 (constant (+el-addfn+ "EL_ADDFN"))

--- a/shell/prompt-types.lisp
+++ b/shell/prompt-types.lisp
@@ -19,7 +19,7 @@
    #:lineinfo #:buffer #:cursor #:lastchar
    #:histevent #:num #:str
    #:+el-prompt+ #:+el-rprompt+ #:+el-editor+ #:+el-bind+ #:+el-addfn+
-   #:+el-hist+
+   #:+el-hist+ #:+el-prompt-esc+
    #:+cc-norm+ #:+cc-newline+ #:+cc-eof+ #:+cc-arghack+ #:+cc-refresh+
    #:+cc-refresh_beep+ #:+cc-cursor+ #:+cc-redisplay+ #:+cc-error+
    #:+cc-fatal+

--- a/shell/prompt.lisp
+++ b/shell/prompt.lisp
@@ -129,6 +129,13 @@ the EL_PROMPT sub-routine of `el-set'."
 the EL_RPROMPT sub-routine of `el-set'."
   (el-set e +el-rprompt+ :pointer prompt-callback))
 
+(defun el-set-prompt-esc (e prompt-callback esc-char)
+  "A wrapper around `el-set' which provides a convenient way to use
+the EL_PROMPT_ESC sub-routine of `el-set'."
+  (el-set e +el-prompt-esc+ 
+          :pointer prompt-callback
+          :char (char-code esc-char)))
+
 (defun el-set-editor (e mode)
   "A wrapper around `el-set' which provides a convenient way to use
 the EL_EDITOR sub-routine of `el-set'."
@@ -230,6 +237,9 @@ object."))
   "This table provides a way to find the instance of the `editline'
 class corresponding to a given `editline-ptr'.")
 
+(defconstant +prompt-escape-char+ (code-char 3)
+             "The character used to start/stop literal sequences. See EL_PROMPT_ESC.")
+
 (defclass editline ()
   ((stdin
     :reader editline-stdin
@@ -314,7 +324,7 @@ encouraged to use `with-editline' to ensure the object is destroyed."
 
            (setf extra-prompt (foreign-string-alloc prompt))
            (setf extra-rprompt (foreign-string-alloc rprompt))
-           (el-set-prompt ptr (callback get-prompt))
+           (el-set-prompt-esc ptr (callback get-prompt) +prompt-escape-char+)
            (el-set-rprompt ptr (callback get-rprompt))
 
            (el-set-editor ptr editor)
@@ -655,11 +665,10 @@ the editline library."
   (princ (code-char #o33)))
 (defmethod escape-sequence ((shell (eql :bash))
                             (char (eql #\[)))
-  )
+  (princ +prompt-escape-char+))
 (defmethod escape-sequence ((shell (eql :bash))
                             (char (eql #\])))
-  )
-
+  (princ +prompt-escape-char+))
 
 ;; Default: copy escape sequence.
 (defmethod escape-sequence (shell char)


### PR DESCRIPTION
Sadly, see this bug report:
  https://mail-index.netbsd.org/netbsd-bugs/2013/02/06/msg031942.html
and this description:
  https://stackoverflow.com/questions/21240181/how-to-colorize-the-prompt-of-an-editline-application

This is still true as of now - multiple escape sequences like with
  PS1='\[\e[1;34m\][\u@\h:\w]$\[\e[0m\]'
are broken, and a single pair like in
  PS1='\[\e[1;34m\u@\h:\w\e[0m\]# '
isn't feature-complete.

We'd need to get rid of editline...