### PR TITLE
Mac support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,15 @@
 
 SHCL_DEBUG=
 
-SHCL_DEPENDS= core/*.lisp shell/*.lisp shcl.asd libshcl-support.so make.lisp
+ifeq ("$(shell uname -s)","Darwin")
+LIBSHCL_SUPPORT=libshcl-support.dylib
+endif
+
+ifeq ("$(shell uname -s)","Linux")
+LIBSHCL_SUPPORT=libshcl-support.so
+endif
+
+SHCL_DEPENDS= core/*.lisp shell/*.lisp shcl.asd ${LIBSHCL_SUPPORT} make.lisp
 SUPPORT_OBJS= core/support/macros.o core/support/spawn.o
 LISP=sbcl
 
@@ -26,7 +34,7 @@ all: shcl
 core/support/spawn.o: core/support/spawn.c core/support/spawn.h Makefile
 	clang -fPIC -o $@ -c $<
 
-libshcl-support.so: ${SUPPORT_OBJS} Makefile
+$(LIBSHCL_SUPPORT): ${SUPPORT_OBJS} Makefile
 	clang -shared -o $@ ${SUPPORT_OBJS}
 
 shcl: ${SHCL_DEPENDS} Makefile

--- a/core/support.lisp
+++ b/core/support.lisp
@@ -25,6 +25,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-foreign-library shcl-support
+    (:darwin (:default "libshcl-support") :search-path ".")
     (:linux (:default "libshcl-support") :search-path ".")))
 
 (use-foreign-library shcl-support)

--- a/core/support/spawn.c
+++ b/core/support/spawn.c
@@ -22,6 +22,15 @@
 #include <string.h>
 #include <errno.h>
 
+#ifdef __APPLE__
+static inline int clearenv(void)
+{
+  extern char **environ;
+  environ = NULL;
+  return 0;
+}
+#endif
+
 enum shcl_fd_action {
     shcl_fd_action_close,
     shcl_fd_action_dup2,


### PR DESCRIPTION
Hi,

Adding support to Mac OS X.

- `clearenv()` is not defined.
- Few changes to the `Makefile` to output with dylib extension.

Let me know if I can improve the rules on Makefile.